### PR TITLE
Improve docker-dind performance and docker libraries fix

### DIFF
--- a/dockerfile-kasm-ubuntu-focal-dind-rootless
+++ b/dockerfile-kasm-ubuntu-focal-dind-rootless
@@ -10,7 +10,7 @@ WORKDIR $HOME
 
 ######### Customize Container Here ###########
 
-ENV DOCKER_BIN=/opt/docker/bin \
+ENV DOCKER_BIN=/usr/local/lib/docker \
     XDG_RUNTIME_DIR=/docker
 
 RUN mkdir -p $DOCKER_BIN && chown 1000:0 $DOCKER_BIN && \

--- a/dockerfile-kasm-ubuntu-focal-dind-rootless
+++ b/dockerfile-kasm-ubuntu-focal-dind-rootless
@@ -10,19 +10,30 @@ WORKDIR $HOME
 
 ######### Customize Container Here ###########
 
-ENV DOCKER_CHANNEL=stable \
-	DOCKER_VERSION=20.10.9 \
-	DOCKER_COMPOSE_VERSION=1.29.2 \
-	DEBUG=false
+ENV DOCKER_BIN=/opt/docker/bin \
+    XDG_RUNTIME_DIR=/docker
 
-COPY ./src/ubuntu/install/dind_rootless $INST_SCRIPTS/dind_rootless/
-RUN bash $INST_SCRIPTS/dind_rootless/install_dind_rootless.sh  && rm -rf $INST_SCRIPTS/dind_rootless/
+RUN mkdir -p $DOCKER_BIN && chown 1000:0 $DOCKER_BIN && \
+    mkdir -p $XDG_RUNTIME_DIR && chown 1000:0 $XDG_RUNTIME_DIR
+
+ENV PATH=$DOCKER_BIN:$DOCKER_BIN/cli-plugins:$PATH \
+        DOCKER_HOST=unix://$XDG_RUNTIME_DIR/docker.sock
+
+COPY ./src/ubuntu/install/dind_rootless/install_dind_rootless_prerequisites.sh $INST_SCRIPTS/dind_rootless/
+RUN bash $INST_SCRIPTS/dind_rootless/install_dind_rootless_prerequisites.sh
+
+COPY ./src/ubuntu/install/dind_rootless/install_dind_rootless.sh $INST_SCRIPTS/dind_rootless/
+RUN chown 1000:1000 $INST_SCRIPTS/dind_rootless/install_dind_rootless.sh
+# It's recommended that docker-rootless be installed by non root user
+USER 1000
+RUN bash $INST_SCRIPTS/dind_rootless/install_dind_rootless.sh
+USER root
+RUN rm -rf $INST_SCRIPTS/dind_rootless
 
 COPY ./src/ubuntu/install/dind_rootless/custom_startup.sh $STARTUPDIR/custom_startup.sh
-RUN chmod +x $STARTUPDIR/custom_startup.sh
-RUN chmod 755 $STARTUPDIR/custom_startup.sh
+RUN chmod +x $STARTUPDIR/custom_startup.sh && chmod 755 $STARTUPDIR/custom_startup.sh
 
-COPY ./src/ubuntu/install/dind/modprobe /usr/local/bin/modprobe
+COPY ./src/ubuntu/install/dind_rootless/modprobe /usr/local/bin/modprobe
 RUN chmod +x /usr/local/bin/modprobe
 
 ### Install Tools
@@ -44,19 +55,6 @@ RUN bash $INST_SCRIPTS/vs_code/install_vs_code.sh  && rm -rf $INST_SCRIPTS/vs_co
 # Install Google Chrome
 COPY ./src/ubuntu/install/chrome $INST_SCRIPTS/chrome/
 RUN bash $INST_SCRIPTS/chrome/install_chrome.sh  && rm -rf $INST_SCRIPTS/chrome/
-
-RUN chown 1000:0 $HOME
-RUN mkdir -p /docker && chown 1000:0 /docker
-USER 1000
-
-### Install docker rootless
-RUN curl -fsSL https://get.docker.com/rootless | sh
-
-ENV XDG_RUNTIME_DIR /docker
-ENV PATH /home/kasm-user/bin:$PATH
-ENV DOCKER_HOST unix:///docker/docker.sock
-
-USER root
 
 ######### End Customizations ###########
 

--- a/src/ubuntu/install/dind_rootless/custom_startup.sh
+++ b/src/ubuntu/install/dind_rootless/custom_startup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -ex
-START_COMMAND="/home/kasm-user/bin/dockerd-rootless.sh"
+START_COMMAND="$DOCKER_BIN/dockerd-rootless.sh"
 PGREP="dockerd"
 export MAXIMIZE="false"
 MAXIMIZE_SCRIPT=$STARTUPDIR/maximize_window.sh

--- a/src/ubuntu/install/dind_rootless/install_dind_rootless.sh
+++ b/src/ubuntu/install/dind_rootless/install_dind_rootless.sh
@@ -1,49 +1,21 @@
 #!/usr/bin/env bash
 set -ex
+# This script should be executed as a non-root user.
+# User verification: deny running as root
+if [ "$(id -u)" = "0" ]; then
+  >&2 echo "Refusing to install rootless Docker as the root user"; exit 1
+fi
 
-apt-get update
-apt-get install -y \
-    ca-certificates \
-    curl \
-    dbus-user-session \
-    kmod \
-    iptables \
-    openssh-client \
-    uidmap \
-    wget
-rm -rf /var/lib/apt/list/*
-
-mkdir -p /var/log/supervisor
-chown -R 1000:1000 /var/log/supervisor
-
-arch="$(uname --m)"; 
-case "$arch" in 
-    # amd64
-    x86_64) dockerArch='x86_64' ;; 
-    # arm32v6
-    armhf) dockerArch='armel' ;;
-    # arm32v7
-    armv7) dockerArch='armhf' ;;
-    # arm64v8
-    aarch64) dockerArch='aarch64' ;;
-    *) echo >&2 "error: unsupported architecture ($arch)"; exit 1 ;;
-esac;
-
-curl -o docker.tgz "https://download.docker.com/linux/static/${DOCKER_CHANNEL}/${dockerArch}/docker-${DOCKER_VERSION}.tgz"
-
-tar --extract \
-    --file docker.tgz \
-    --strip-components 1 \
-    --directory /usr/local/bin/
-rm docker.tgz
+echo "Installing Docker"
+curl -fsSL https://get.docker.com/rootless | sh
 
 dockerd --version
 docker --version
 
 echo "Installing Docker Compose"
-mkdir -p /usr/local/lib/docker/cli-plugins
+mkdir -p "${DOCKER_BIN}"/cli-plugins
 COMPOSE_RELEASE=$(curl -sX GET "https://api.github.com/repos/docker/compose/releases/latest" \
     | awk '/tag_name/{print $4;exit}' FS='[""]');
 COMPOSE_OS=$(uname -s)
-curl -L https://github.com/docker/compose/releases/download/${COMPOSE_RELEASE}/docker-compose-${COMPOSE_OS,,}-$(uname -m) -o /usr/local/lib/docker/cli-plugins/docker-compose
-chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+curl -L https://github.com/docker/compose/releases/download/"${COMPOSE_RELEASE}"/docker-compose-"${COMPOSE_OS,,}"-"$(uname -m)" -o "${DOCKER_BIN}"/cli-plugins/docker-compose
+chmod +x "${DOCKER_BIN}"/cli-plugins/docker-compose

--- a/src/ubuntu/install/dind_rootless/install_dind_rootless_prerequisites.sh
+++ b/src/ubuntu/install/dind_rootless/install_dind_rootless_prerequisites.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -ex
+
+apt-get update && apt-get install -y \
+    ca-certificates \
+    curl \
+    dbus-user-session \
+    fuse-overlayfs \
+    kmod \
+    iptables \
+    openssh-client \
+    uidmap \
+    wget \
+    slirp4netns \
+    pigz \
+    xz-utils \
+    iproute2 \
+    xfsprogs \
+    btrfs-progs \
+    e2fsprogs && \
+rm -rf /var/lib/apt/list/*


### PR DESCRIPTION
- fixes the issue where there were two docker binaries installed in two different locations $HOME/bin and /usr/local/bin/ (see images below)
- install docker rootless at /opt/docker/bin and puts in on path 
- install docker compose at /opt/docker/bin/cli-plugins and put it on the path 
- install additional libraries notably fuse-overlayfs which is recommended over vbr (tests only). vbr driver has a very poor performance. Likewise slirp4netns is recommended for as network driver over vpnkit (https://docs.docker.com/engine/security/rootless/)
![Screen Shot 2022-06-09 at 12 54 06 AM](https://user-images.githubusercontent.com/33968665/173172317-d0ac7c7d-b961-4fb7-adcf-5fb6d1c5d6d3.png)
