### PR TITLE
fix: demo link in readme led to a non-existent page

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Kasm Workspaces is a docker container streaming platform that enables you to del
 Kasm Workspaces was developed to meet the most demanding secure collaboration requirements that is highly scalable, customizable, and easy to maintain.  Most importantly, Kasm provides a solution, rather than a service, so it is infinitely customizable to your unique requirements and includes a developer API so that it can be integrated with, rather than replace, your existing applications and workflows. Kasm can be deployed in the cloud (Public or Private), on-premise (Including Air-Gapped Networks), or in a hybrid configuration.
 
 # Live Demo
-A self-guided on-demand demo is available at [**kasmweb.com**](https://www.kasmweb.com/demo.html?utm_campaign=Github&utm_source=github)
+A self-guided on-demand demo is available at [**kasmweb.com**](https://www.kasmweb.com/cloud-personal#demo?utm_campaign=Github&utm_source=github)
 
 
 [logo]: https://cdn2.hubspot.net/hubfs/5856039/dockerhub/kasm_logo.png "Kasm Logo"

--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ Kasm Workspaces is a docker container streaming platform that enables you to del
 Kasm Workspaces was developed to meet the most demanding secure collaboration requirements that is highly scalable, customizable, and easy to maintain.  Most importantly, Kasm provides a solution, rather than a service, so it is infinitely customizable to your unique requirements and includes a developer API so that it can be integrated with, rather than replace, your existing applications and workflows. Kasm can be deployed in the cloud (Public or Private), on-premise (Including Air-Gapped Networks), or in a hybrid configuration.
 
 # Live Demo
-A self-guided on-demand demo is available at [**kasmweb.com**](https://www.kasmweb.com/cloud-personal#demo?utm_campaign=Github&utm_source=github)
+A self-guided on-demand demo for, personal use, is available at [**kasmweb.com**](https://www.kasmweb.com/cloud-personal#demo?utm_campaign=Github&utm_source=github)
 
+Self-guided on-demand demos for, businesses, are also available at [**kasmweb.com**](https://www.kasmweb.com/#demo?utm_campaign=Github&utm_source=github)
 
 [logo]: https://cdn2.hubspot.net/hubfs/5856039/dockerhub/kasm_logo.png "Kasm Logo"
 [Kasm_Workflow]: https://cdn2.hubspot.net/hubfs/5856039/dockerhub/kasm_workflow_960.gif "Kasm Workflow"

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ Kasm Workspaces is a docker container streaming platform that enables you to del
 Kasm Workspaces was developed to meet the most demanding secure collaboration requirements that is highly scalable, customizable, and easy to maintain.  Most importantly, Kasm provides a solution, rather than a service, so it is infinitely customizable to your unique requirements and includes a developer API so that it can be integrated with, rather than replace, your existing applications and workflows. Kasm can be deployed in the cloud (Public or Private), on-premise (Including Air-Gapped Networks), or in a hybrid configuration.
 
 # Live Demo
-A self-guided on-demand demo for, personal use, is available at [**kasmweb.com**](https://www.kasmweb.com/cloud-personal#demo?utm_campaign=Github&utm_source=github)
+A self-guided on-demand demo for personal use is available at [**kasmweb.com**](https://www.kasmweb.com/cloud-personal#demo?utm_campaign=Github&utm_source=github)
 
-Self-guided on-demand demos for, businesses, are also available at [**kasmweb.com**](https://www.kasmweb.com/#demo?utm_campaign=Github&utm_source=github)
+Self-guided on-demand demos for businesses are also available at [**kasmweb.com**](https://www.kasmweb.com/#demo?utm_campaign=Github&utm_source=github)
 
 [logo]: https://cdn2.hubspot.net/hubfs/5856039/dockerhub/kasm_logo.png "Kasm Logo"
 [Kasm_Workflow]: https://cdn2.hubspot.net/hubfs/5856039/dockerhub/kasm_workflow_960.gif "Kasm Workflow"


### PR DESCRIPTION
I fixed the link for the demo, and I specificed that there are both business and personal demos available. 