### PR TITLE
Add  cursor build dockerfiles

### DIFF
--- a/dockerfile-kasm-cursor
+++ b/dockerfile-kasm-cursor
@@ -1,0 +1,40 @@
+ARG BASE_TAG="develop"
+ARG BASE_IMAGE="core-ubuntu-focal"
+FROM kasmweb/$BASE_IMAGE:$BASE_TAG
+USER root
+
+ENV HOME /home/kasm-default-profile
+ENV STARTUPDIR /dockerstartup
+ENV INST_SCRIPTS $STARTUPDIR/install
+ENV DONT_PROMPT_WSL_INSTALL "No_Prompt_please"
+WORKDIR $HOME
+
+######### Customize Container Here ###########
+
+# Install Google Chrome
+COPY ./src/ubuntu/install/chrome $INST_SCRIPTS/chrome/
+RUN bash $INST_SCRIPTS/chrome/install_chrome.sh  && rm -rf $INST_SCRIPTS/chrome/
+
+
+COPY ./src/ubuntu/install/cursor $INST_SCRIPTS/cursor/
+RUN bash $INST_SCRIPTS/cursor/install_cursor.sh  && rm -rf $INST_SCRIPTS/cursor/
+
+COPY ./src/ubuntu/install/cursor/custom_startup.sh $STARTUPDIR/custom_startup.sh
+RUN chmod +x $STARTUPDIR/custom_startup.sh
+RUN chmod 755 $STARTUPDIR/custom_startup.sh
+
+
+# Update the desktop environment to be optimized for a single application
+RUN cp $HOME/.config/xfce4/xfconf/single-application-xfce-perchannel-xml/* $HOME/.config/xfce4/xfconf/xfce-perchannel-xml/
+RUN cp /usr/share/backgrounds/bg_kasm.png /usr/share/backgrounds/bg_default.png
+RUN apt-get remove -y xfce4-panel
+
+######### End Customizations ###########
+
+RUN chown 1000:0 $HOME
+
+ENV HOME /home/kasm-user
+WORKDIR $HOME
+RUN mkdir -p $HOME && chown -R 1000:0 $HOME
+
+USER 1000

--- a/src/ubuntu/install/cursor/custom_startup.sh
+++ b/src/ubuntu/install/cursor/custom_startup.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -ex
+START_COMMAND="/usr/share/cursor/AppRun"
+PGREP="cursor"
+export MAXIMIZE="true"
+export MAXIMIZE_NAME="Cursor"
+export APPDIR="/usr/share/cursor"
+MAXIMIZE_SCRIPT=$STARTUPDIR/maximize_window.sh
+DEFAULT_ARGS="--no-sandbox"
+ARGS=${APP_ARGS:-$DEFAULT_ARGS}
+
+options=$(getopt -o gau: -l go,assign,url: -n "$0" -- "$@") || exit
+eval set -- "$options"
+
+while [[ $1 != -- ]]; do
+    case $1 in
+        -g|--go) GO='true'; shift 1;;
+        -a|--assign) ASSIGN='true'; shift 1;;
+        -u|--url) OPT_URL=$2; shift 2;;
+        *) echo "bad option: $1" >&2; exit 1;;
+    esac
+done
+shift
+
+# Process non-option arguments.
+for arg; do
+    echo "arg! $arg"
+done
+
+FORCE=$2
+
+kasm_exec() {
+    if [ -n "$OPT_URL" ] ; then
+        URL=$OPT_URL
+    elif [ -n "$1" ] ; then
+        URL=$1
+    fi 
+    
+    # Since we are execing into a container that already has the browser running from startup, 
+    #  when we don't have a URL to open we want to do nothing. Otherwise a second browser instance would open. 
+    if [ -n "$URL" ] ; then
+        /usr/bin/filter_ready
+        /usr/bin/desktop_ready
+        bash ${MAXIMIZE_SCRIPT} &
+        $START_COMMAND $ARGS $OPT_URL
+    else
+        echo "No URL specified for exec command. Doing nothing."
+    fi
+}
+
+kasm_startup() {
+    if [ -n "$KASM_URL" ] ; then
+        URL=$KASM_URL
+    elif [ -z "$URL" ] ; then
+        URL=$LAUNCH_URL
+    fi
+
+    if [ -z "$DISABLE_CUSTOM_STARTUP" ] ||  [ -n "$FORCE" ] ; then
+
+        echo "Entering process startup loop"
+        set +x
+        while true
+        do
+            if ! pgrep -x $PGREP > /dev/null
+            then
+                /usr/bin/filter_ready
+                /usr/bin/desktop_ready
+                set +e
+                bash ${MAXIMIZE_SCRIPT} &
+                $START_COMMAND $ARGS $URL
+                set -e
+            fi
+            sleep 1
+        done
+        set -x
+    
+    fi
+
+} 
+
+if [ -n "$GO" ] || [ -n "$ASSIGN" ] ; then
+    kasm_exec
+else
+    kasm_startup
+fi

--- a/src/ubuntu/install/cursor/install_cursor.sh
+++ b/src/ubuntu/install/cursor/install_cursor.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -ex
+
+# Install vsCode
+cd /dockerstartup/install/cursor/
+wget -q "https://downloader.cursor.sh/linux/appImage/x64" -O cursor.AppImage
+chmod +x cursor.AppImage
+./cursor.AppImage --appimage-extract
+mv squashfs-root /usr/share/cursor
+cp .config/Cursor $HOME/.config/ -a
+cp .cursor $HOME/ -a
+chown 1000:1000 $HOME/.config/Cursor
+chown 1000:1000 $HOME/.cursor
+
+# Desktop icon
+mkdir -p /usr/share/icons/hicolor/apps
+wget -O /usr/share/icons/hicolor/apps/cursor.png "https://miro.medium.com/v2/resize:fit:256/format:webp/1*YLg8VpqXaTyRHJoStnMuog.png"
+sed -i '/Icon=/c\Icon=/usr/share/icons/hicolor/apps/cursor.png' /usr/share/cursor/cursor.desktop
+sed -i 's#Exec=#Exec=/usr/share/cursor/#' /usr/share/cursor/cursor.desktop
+cp /usr/share/cursor/cursor.desktop $HOME/Desktop
+chmod +x  $HOME/Desktop/cursor.desktop
+chmod 755 -R /usr/share/cursor
+chmod +x  /usr/share/cursor/AppRun
+chmod +x  /usr/share/cursor/cursor
+chown 1000:1000 $HOME/Desktop/cursor.desktop
+
+rm cursor.AppImage
+
+# Conveniences for python development
+apt-get update
+apt-get install -y python3-setuptools \
+                   python3-venv \
+                   python3-virtualenv
+# Cleanup for app layer
+chown -R 1000:0 $HOME
+find /usr/share/ -name "icon-theme.cache" -exec rm -f {} \;
+if [ -z ${SKIP_CLEAN+x} ]; then
+  apt-get autoclean
+  rm -rf \
+    /var/lib/apt/lists/* \
+    /var/tmp/* \
+    /tmp/*
+fi

--- a/src/ubuntu/install/cursor/install_cursor.sh
+++ b/src/ubuntu/install/cursor/install_cursor.sh
@@ -7,10 +7,6 @@ wget -q "https://downloader.cursor.sh/linux/appImage/x64" -O cursor.AppImage
 chmod +x cursor.AppImage
 ./cursor.AppImage --appimage-extract
 mv squashfs-root /usr/share/cursor
-cp .config/Cursor $HOME/.config/ -a
-cp .cursor $HOME/ -a
-chown 1000:1000 $HOME/.config/Cursor
-chown 1000:1000 $HOME/.cursor
 
 # Desktop icon
 mkdir -p /usr/share/icons/hicolor/apps


### PR DESCRIPTION
This merge request adds support for building the Cursor app in a Docker environment. The Dockerfile is based on the `kasmweb/core-ubuntu-focal:develop` image and includes the necessary steps to pull, extract, and install the Cursor AppImage.

**Changes:**
- Added Dockerfiles to support the Cursor app.
- Based on the `kasmweb/core-ubuntu-focal:develop` image.
- Added scripts to handle the pulling, extraction, and installation of the Cursor AppImage.

**Build Instructions:**
To build the Cursor app Docker image, use the following command:
```bash
docker build -t cursor:0.1 -f dockerfile-kasm-cursor .
```


