### PR TITLE
Fixed the APP_ARGS parsing error that caused multiple Windows

### DIFF
--- a/src/ubuntu/install/chrome/custom_startup.sh
+++ b/src/ubuntu/install/chrome/custom_startup.sh
@@ -66,7 +66,7 @@ kasm_startup() {
                 /usr/bin/filter_ready
                 /usr/bin/desktop_ready
                 set +e
-                $START_COMMAND $ARGS $URL
+                printf "%q " "$START_COMMAND" "${ARGS[@]}" "$URL" | xargs -0 sh -c
                 set -e
             fi
             sleep 1


### PR DESCRIPTION
When I start Chrome using a command
`sudo docker run --rm -it --shm-size=512m -p 6901:6901 -e VNC_PW=password -e APP_ARGS=--user-agent="Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Mobile/15E148 Safari/604.1" kasmweb/chrome:1.17.0`

The APP_ARGS parsing error resulted in multiple Windows

<img width="1625" height="557" alt="图片" src="https://github.com/user-attachments/assets/530880a5-17f5-43cd-a017-8dc1cf900ffe" />

So I modified the script startup parameters to make the startup command parse correctly