### PR TITLE
Fix almalinux typos

### DIFF
--- a/dockerfile-kasm-almalinux-9-desktop
+++ b/dockerfile-kasm-almalinux-9-desktop
@@ -1,5 +1,5 @@
 ARG BASE_TAG="develop"
-ARG BASE_IMAGE="core-alamalinux-9"
+ARG BASE_IMAGE="core-almalinux-9"
 FROM kasmweb/$BASE_IMAGE:$BASE_TAG
 
 USER root

--- a/docs/almalinux-8-desktop/README.md
+++ b/docs/almalinux-8-desktop/README.md
@@ -4,4 +4,4 @@ This Image contains a browser-accessible AlmaLinux 8 Desktop with various produc
 
 ![Screenshot][Image_Screenshot]
 
-[Image_Screenshot]: https://info.kasmweb.com/hubfs/dockerhub/image-screenshots/alamalinux-8-desktop.png "Image Screenshot"
+[Image_Screenshot]: https://info.kasmweb.com/hubfs/dockerhub/image-screenshots/almalinux-8-desktop.png "Image Screenshot"


### PR DESCRIPTION
The PNG filename needs to be edited on `https://info.kasmweb.com/hubfs/dockerhub/image-screenshots/almalinux-8-desktop.png` as well.