### PR TITLE
feat: added ubuntu jammy cuda dind dockerfile

### DIFF
--- a/ci-scripts/template-vars.yaml
+++ b/ci-scripts/template-vars.yaml
@@ -687,6 +687,21 @@ multiImages:
       - src/ubuntu/install/cleanup/**
       - src/ubuntu/install/chromium/**
       - src/ubuntu/install/chrome/**
+  - name: cuda-jammy-dind
+    runset: set-b
+    singleapp: false
+    base: core-cuda-jammy
+    dockerfile: dockerfile-kasm-cuda-jammy-dind
+    changeFiles:
+      - dockerfile-kasm-cuda-jammy-dind
+      - src/ubuntu/install/vs_code/**
+      - src/ubuntu/install/tools/**
+      - src/ubuntu/install/sublime_text/**
+      - src/ubuntu/install/misc/**
+      - src/ubuntu/install/dind/**
+      - src/ubuntu/install/cleanup/**
+      - src/ubuntu/install/chromium/**
+      - src/ubuntu/install/chrome/**
   - name: ubuntu-jammy-dind-rootless
     runset: set-a
     singleapp: false

--- a/dockerfile-kasm-cuda-jammy-dind
+++ b/dockerfile-kasm-cuda-jammy-dind
@@ -1,0 +1,51 @@
+ARG BASE_TAG="develop"
+ARG BASE_IMAGE="core-cuda-jammy"
+FROM kasmweb/$BASE_IMAGE:$BASE_TAG
+USER root
+
+ENV HOME /home/kasm-default-profile
+ENV STARTUPDIR /dockerstartup
+WORKDIR $HOME
+
+### Envrionment config
+ENV DEBUG=false \
+    DEBIAN_FRONTEND=noninteractive \
+    SKIP_CLEAN=true \
+    KASM_RX_HOME=$STARTUPDIR/kasmrx \
+    DONT_PROMPT_WSL_INSTALL="No_Prompt_please" \
+    INST_DIR=$STARTUPDIR/install \
+    INST_SCRIPTS="/ubuntu/install/dind/install_dind.sh \
+                  /ubuntu/install/tools/install_tools_deluxe.sh \
+                  /ubuntu/install/misc/install_tools.sh \
+                  /ubuntu/install/chrome/install_chrome.sh \
+                  /ubuntu/install/chromium/install_chromium.sh \
+                  /ubuntu/install/sublime_text/install_sublime_text.sh \
+                  /ubuntu/install/vs_code/install_vs_code.sh \
+                  /ubuntu/install/cleanup/cleanup.sh"
+
+# Startup Scripts
+COPY ./src/ubuntu/install/dind/custom_startup.sh $STARTUPDIR/custom_startup.sh
+RUN chmod 755 $STARTUPDIR/custom_startup.sh
+COPY ./src/ubuntu/install/dind/dockerd.conf /etc/supervisor/conf.d/
+
+# Copy install scripts
+COPY ./src/ $INST_DIR
+
+# Run installations
+RUN \
+  for SCRIPT in $INST_SCRIPTS; do \
+    bash ${INST_DIR}${SCRIPT} || exit 1; \
+  done && \
+  $STARTUPDIR/set_user_permission.sh $HOME && \
+  rm -f /etc/X11/xinit/Xclients && \
+  chown 1000:0 $HOME && \
+  mkdir -p /home/kasm-user && \
+  chown -R 1000:0 /home/kasm-user && \
+  rm -Rf ${INST_DIR}
+
+# Userspace Runtime
+ENV HOME /home/kasm-user
+WORKDIR $HOME
+USER 1000
+
+CMD ["--tail-log"]


### PR DESCRIPTION
KASM suite of docker images have both dind (docker in docker) images and also cuda images available. 

For the ultimate KASM development image, it would be nice to have an image that combines both - dind and docker. 
This is a great choice for all round development work that requires building and running docker images while also supporting cuda toolkit for ML or other compute tasks. 

This PR adds an additional docker image which inherits from "cuda-jammy" base and adds "dind" on top.
