### PR TITLE
Fix case sensitivity in Firefox version retrieval

### DIFF
--- a/src/ubuntu/install/firefox/install_firefox.sh
+++ b/src/ubuntu/install/firefox/install_firefox.sh
@@ -64,7 +64,7 @@ else
 fi
 
 # Add Langpacks
-FIREFOX_VERSION=$(curl -sI https://download.mozilla.org/?product=firefox-latest | awk -F '(releases/|/win32)' '/Location/ {print $2}')
+FIREFOX_VERSION=$(curl -sI https://download.mozilla.org/?product=firefox-latest | awk -F '(releases/|/win32)' '/location/ {print $2}')
 RELEASE_URL="https://releases.mozilla.org/pub/firefox/releases/${FIREFOX_VERSION}/win64/xpi/"
 LANGS=$(curl -Ls ${RELEASE_URL} | awk -F '(xpi">|</a>)' '/href.*xpi/ {print $2}' | tr '\n' ' ')
 EXTENSION_DIR=/usr/lib/firefox-addons/distribution/extensions/


### PR DESCRIPTION
Location is all lowercase:
```shell
$ curl -sI https://download.mozilla.org/?product=firefox-latest
HTTP/2 302
server: nginx
date: Sun, 01 Feb 2026 17:28:59 GMT
content-type: text/html; charset=utf-8
content-length: 136
cache-control: max-age=60
location: https://download-installer.cdn.mozilla.net/pub/firefox/releases/147.0.2/win32/en-US/Firefox%20Setup%20147.0.2.exe
via: 1.1 google
alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
```