### PR TITLE
Fix discord paths

### DIFF
--- a/src/ubuntu/install/discord/custom_startup.sh
+++ b/src/ubuntu/install/discord/custom_startup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 START_COMMAND="/usr/bin/discord"
-PGREP="Discord"
+PGREP="discord"
 export MAXIMIZE="true"
 export MAXIMIZE_NAME="Discord"
 MAXIMIZE_SCRIPT=$STARTUPDIR/maximize_window.sh

--- a/src/ubuntu/install/discord/custom_startup.sh
+++ b/src/ubuntu/install/discord/custom_startup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -ex
-START_COMMAND="/usr/share/discord/Discord"
+START_COMMAND="/usr/bin/discord"
 PGREP="Discord"
 export MAXIMIZE="true"
 export MAXIMIZE_NAME="Discord"

--- a/src/ubuntu/install/discord/install_discord.sh
+++ b/src/ubuntu/install/discord/install_discord.sh
@@ -12,7 +12,7 @@ mkdir -p $HOME/.config/discord/
 echo '{"SKIP_HOST_UPDATE": true}' > $HOME/.config/discord/settings.json
 
 # Desktop file setup
-sed -i "s@Exec=/usr/share/discord/Discord@Exec=/usr/share/discord/Discord --no-sandbox@g"  /usr/share/applications/discord.desktop
+sed -i "s@Exec=/usr/bin/discord@Exec=/usr/bin/discord --no-sandbox@g"  /usr/share/applications/discord.desktop
 cp /usr/share/applications/discord.desktop $HOME/Desktop/
 chmod +x $HOME/Desktop/discord.desktop
 


### PR DESCRIPTION
Running the current discord images leads to 'No such file or directory' error messages:

```
[...]
2026-05-14 11:04:19,266 - ERROR - bridge->relay: timeout: 0x01
filter is not configured
/dockerstartup/custom_startup.sh: line 69: /usr/share/discord/Discord: No such file or directory
filter is not configured
/dockerstartup/custom_startup.sh: line 69: /usr/share/discord/Discord: No such file or directory
filter is not configured
/dockerstartup/custom_startup.sh: line 69: /usr/share/discord/Discord: No such file or directory
filter is not configured
/dockerstartup/custom_startup.sh: line 69: /usr/share/discord/Discord: No such file or directory
filter is not configured
/dockerstartup/custom_startup.sh: line 69: /usr/share/discord/Discord: No such file or directory
filter is not configured
/dockerstartup/custom_startup.sh: line 69: /usr/share/discord/Discord: No such file or directory
filter is not configured
/dockerstartup/custom_startup.sh: line 69: /usr/share/discord/Discord: No such file or directory
filter is not configured
/dockerstartup/custom_startup.sh: line 69: /usr/share/discord/Discord: No such file or directory
2026-05-14 11:04:26,771 - ERROR - bridge->relay: timeout: 0x01
filter is not configured
/dockerstartup/custom_startup.sh: line 69: /usr/share/discord/Discord: No such file or directory
filter is not configured
/dockerstartup/custom_startup.sh: line 69: /usr/share/discord/Discord: No such file or directory
filter is not configured
/dockerstartup/custom_startup.sh: line 69: /usr/share/discord/Discord: No such file or directory
filter is not configured
/dockerstartup/custom_startup.sh: line 69: /usr/share/discord/Discord: No such file or directory
filter is not configured
/dockerstartup/custom_startup.sh: line 69: /usr/share/discord/Discord: No such file or directory
filter is not configured
/dockerstartup/custom_startup.sh: line 69: /usr/share/discord/Discord: No such file or directory
filter is not configured
/dockerstartup/custom_startup.sh: line 69: /usr/share/discord/Discord: No such file or directory
```

Discord changed the path of the executable (or at least removed `/usr/share/discord/Discord`) in one of the last updates, probably as part of the new update mechanism described in their [May 4 changes](https://discord.com/blog/discord-patch-notes-may-4-2026):

> Are you a Linux user? If so, are you sick of that lovely modal we made to tell you that there’s an update you need to go manually install? IF SO, boy do I have good news for you. We’ve ported our Rust-based updater to Linux, allowing Linux to update itself just like on Windows. Additionally, we now support .rpm and .pkg.tar.zst package formats for installation.


This PR fixes this by using the new path / executable in the install & startup scripts. I've tested the image built with the new scripts and it works as before.